### PR TITLE
forward compatiblity with lark-parser>=0.7.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,22 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.3.0
+  rev: v4.0.1
   hooks:
   - id: check-added-large-files
   - id: debug-statements
   - id: end-of-file-fixer
 - repo: https://github.com/timothycrosley/isort
-  rev: master
+  rev: 5.9.3
   hooks:
   - id: isort
     additional_dependencies:
     - isort[pyproject]
 - repo: https://github.com/psf/black
-  rev: stable
+  rev: 21.9b0
   hooks:
   - id: black
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.730
+  rev: v0.910
   hooks:
   - id: mypy
     exclude: tests

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,6 +21,8 @@ def lint(session):
     else:
         args = ["--all-files", "--show-diff-on-failure"]
 
+    session.run("pre-commit", "autoupdate")
+
     session.run("pre-commit", "run", *args)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ home-page = "https://github.com/chrahunt/strace-parser"
 license = "MIT"
 module = "strace_parser"
 requires = [
-    "lark-parser==0.7.8",
+    "lark-parser>=0.7.8",
 ]
 requires-python = ">=3.8.0"
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -2,6 +2,7 @@ from importlib.resources import read_text
 
 import pytest
 from lark import Token, Tree
+
 from strace_parser.json_transformer import to_json
 from strace_parser.parser import get_parser
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,6 +1,7 @@
 from importlib.resources import read_text
 
 import pytest
+
 import tests.data
 from strace_parser.parser import get_parser
 


### PR DESCRIPTION
Can we update requirements to lark-parser>=0.7.8 ? The strace-parser seems to be compatible with recent version of lark-parser 0.8.5